### PR TITLE
chore: bump Go to 1.26.0

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -12,7 +12,7 @@ plugins:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.24.0
+    - go@1.26.0
     - node@18.20.5
     - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Sawmills/ddqp
 
-go 1.24
+go 1.26.0
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.1


### PR DESCRIPTION
## Summary
- Bumps `go` directive in `go.mod` to `1.26.0`
- Runs `go mod tidy` to update `go.sum`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change; primary risk is CI/build incompatibility if environments aren’t updated to Go 1.26.0.
> 
> **Overview**
> Bumps the project’s Go version to `1.26.0` by updating the `go` directive in `go.mod` and the Go runtime used by Trunk (`.trunk/trunk.yaml`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cc67a3edb9c4f3c5d86c4f9935a8b810e8d107a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Go toolchain to 1.26.0 across the repo. Updates go.mod and .trunk/trunk.yaml so local, CI, and Trunk tools use Go 1.26.0.

- **Migration**
  - Install Go 1.26.0+ locally.
  - Ensure CI/build images and Trunk runtimes use Go 1.26.0.

<sup>Written for commit 5cc67a3edb9c4f3c5d86c4f9935a8b810e8d107a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go language version across the project to 1.26.0.
  * Updated runtime configuration to reflect Go 1.26.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->